### PR TITLE
Fix typos in README and extend readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
 - uses: actions/setup-java@v1
   with:
     java-version: '9.0.4' // The JDK version to make available on the path. Required to run any clojure command line tools.
-- uses: DeLaGuardo/setup-clojure@1.0
+- uses: DeLaGuardo/setup-clojure@2.0
   with:
     tools-deps: '1.10.1.469'
 - run: clojure -Sdescribe

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action sets up clojure tools environment for using in GitHub Actions.
 ```yaml
 steps:
 - uses: actions/checkout@latest
-- uses: action/setup-java@v1
+- uses: actions/setup-java@v1
   with:
     java-version: '9.0.4' // The JDK version to make available on the path. Required to run any clojure command line tools.
 - uses: DeLaGuardo/setup-clojure@1.0

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # setup-clojure
 
-This action sets up clojure tools environment for using in GitHub Actions.
+This action sets up Clojure tools environment for using in GitHub Actions.
 
-* clojure cli
-* leiningen
+* Clojure CLI
+* Leiningen
 * boot-clj
 
 # Usage
 
+Here is a snippet for your workflow file:
+
 ```yaml
 steps:
-- uses: actions/checkout@latest
-- uses: actions/setup-java@v1
-  with:
-    java-version: '9.0.4' // The JDK version to make available on the path. Required to run any clojure command line tools.
-- uses: DeLaGuardo/setup-clojure@2.0
-  with:
-    tools-deps: '1.10.1.469'
-- run: clojure -Sdescribe
+  - uses: actions/checkout@latest
+  - uses: actions/setup-java@v1
+    with:
+      java-version: '9.0.4' // The JDK version to make available on the path. Required to run any clojure command line tools.
+  - uses: DeLaGuardo/setup-clojure@2.0
+    with:
+      tools-deps: '1.10.1.469'
+  - run: clojure -Sdescribe
 ```
 
-For more usecases please check [Smoke Test Workflow file](https://github.com/DeLaGuardo/setup-clojure/blob/master/.github/workflows/smoke-tests.yml)
+For more application cases please check [Smoke Test Workflow file](https://github.com/DeLaGuardo/setup-clojure/blob/master/.github/workflows/smoke-tests.yml)
 
 # License
 


### PR DESCRIPTION
There was a typo in your description (see 2500ade), which causes workflows to fail. 

Also I fixed the indentation of the yml snippet.

Thanks for this project, I like it and am using it in a project of mine ([n2o/reveal-cljs](https://github.com/n2o/reveal-cljs))