### PR TITLE
Point to cli in tools-deps on windows error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3455,7 +3455,7 @@ function run() {
             }
             if (TDEPS_VERSION) {
                 if (IS_WINDOWS) {
-                    throw new Error('Clojure tools.deps on windows is not supported yet.');
+                    throw new Error('tools-deps on windows is not supported. Use cli instead as tools-deps is deprecated.');
                 }
                 cli.setup(TDEPS_VERSION);
             }


### PR DESCRIPTION
I was updating an old Windows build and was a little confused at `tools-deps` not working on Windows. I just needed to use  `cli` instead.