### PR TITLE
Set the GitHub token as default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
     description: 'The boot-clj version to make available on the path.'
   tools-deps:
     description: '[DEPRECATED] The tools deps version to make available on the path.'
+    deprecationMessage: 'Use the `cli` input instead'
   cli:
     description: 'Clojure CLI version to make available on the path.'
   bb:
@@ -19,6 +20,8 @@ inputs:
     description: >+
       To fix rate limit errors, provide `secrets.GITHUB_TOKEN` value to this field.
       More info: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    default: ${{ github.token }}
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR sets the GitHub Token as default.

[The docker/build-push-action does it as well](https://github.com/docker/build-push-action/blob/ac9327eae2b366085ac7f6a2d02df8aa8ead720a/action.yml#L89)
