### PR TITLE
Update versions of other actions in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '8'


### PR DESCRIPTION
I noticed that these were out of date and I figure it couldn’t hurt to
keep the ancillary aspects of the example up to date, just in case
people copy-pasta the whole example.

Speaking of which, I was also tempted to add `cache: maven` to
the `setup-java` args since it seems like a good default to me, but
I held off just to keep this change focused on one specific kind of
change. That said, I do think that’d be a good idea.