### PR TITLE
Add arch to cache key

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -39,7 +39,7 @@ export async function restore(
 }
 
 function getCacheKey(identifier: string, version: string): string {
-  return `setupclojure-${os.platform()}-${VERSION}-${identifier}-${version}`
+  return `setupclojure-${os.platform()}-${os.arch()}-${VERSION}-${identifier}-${version}`
 }
 
 function getCachePaths(identifier: string): string[] {


### PR DESCRIPTION
I was still seeing the x86-64 version installed in my self-hosted arm64 runner when using version 9.5, even after destroying and recreating it. So it seemed like a caching thing.