### PR TITLE
Ignore cache if invalidate-cache: true

### DIFF
--- a/src/babashka.ts
+++ b/src/babashka.ts
@@ -57,7 +57,7 @@ export async function setup(
   const ver =
     version === 'latest' ? await getLatestBabashka(githubAuth) : version
 
-  let toolDir = tc.find(identifier, ver)
+  let toolDir = core.getBooleanInput('invalidate-cache') ? null : tc.find(identifier, ver)
   if (!toolDir) {
     const archiveUrl = getArtifactUrl(ver)
     const archiveDir = await tc.downloadTool(archiveUrl, undefined, githubAuth)

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -32,7 +32,7 @@ export async function setup(
   version: string,
   githubAuth?: string
 ): Promise<void> {
-  let toolPath = tc.find(
+  let toolPath = core.getBooleanInput('invalidate-cache') ? null : tc.find(
     identifier,
     utils.getCacheVersionString(version),
     os.arch()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ export async function setup(
   const installDir = utils.isWindows()
     ? 'C:\\Program Files\\WindowsPowerShell\\Modules'
     : '/tmp/usr/local/opt'
-  const toolPath = tc.find(
+  const toolPath = core.getBooleanInput('invalidate-cache') ? null : tc.find(
     identifier,
     utils.getCacheVersionString(version),
     os.arch()

--- a/src/clj-kondo.ts
+++ b/src/clj-kondo.ts
@@ -48,7 +48,7 @@ export async function setup(
   const ver =
     version === 'latest' ? await getLatestCljKondo(githubAuth) : version
 
-  let toolDir = tc.find(identifier, ver)
+  let toolDir = core.getBooleanInput('invalidate-cach') ? null : tc.find(identifier, ver)
   if (!toolDir) {
     const archiveUrl = getArtifactUrl(ver)
     core.info(`Downloading: ${archiveUrl}`)

--- a/src/cljstyle.ts
+++ b/src/cljstyle.ts
@@ -46,7 +46,7 @@ export async function setup(
   const ver =
     version === 'latest' ? await getLatestCljstyle(githubAuth) : version
 
-  let toolDir = tc.find(identifier, ver)
+  let toolDir = core.getBooleanInput('invalidate-cache') ? null : tc.find(identifier, ver)
   if (!toolDir) {
     const archiveUrl = getArtifactUrl(ver)
     core.info(`Downloading: ${archiveUrl}`)

--- a/src/leiningen.ts
+++ b/src/leiningen.ts
@@ -15,7 +15,7 @@ export async function setup(
 ): Promise<void> {
   const isWindows = utils.isWindows()
 
-  let toolPath = tc.find(
+  let toolPath = core.getBooleanInput('invalidate-cache') ? null : tc.find(
     identifier,
     utils.getCacheVersionString(version),
     os.arch()

--- a/src/zprint.ts
+++ b/src/zprint.ts
@@ -48,7 +48,7 @@ export async function setup(
 ): Promise<void> {
   const ver = version === 'latest' ? await getLatestZprint(githubAuth) : version
 
-  let toolDir = tc.find(identifier, ver)
+  let toolDir = core.getBooleanInput('invalidate-cache') ? null : tc.find(identifier, ver)
   if (!toolDir) {
     const archiveUrl = getArtifactUrl(ver)
     core.info(`Artifact: ${archiveUrl}`)


### PR DESCRIPTION
This is needed on self-hosted runners which persist their tool caches locally where the "restore cache" step puts everything on GitHub-provided runners. So we have to ignore that for `invalidate-cache: true` to work there.

Closes #73 